### PR TITLE
Add feature to extract keys from a pattern without needing to parse a string

### DIFF
--- a/source/lucidity/template.py
+++ b/source/lucidity/template.py
@@ -37,6 +37,7 @@ class Template(object):
         self._anchor = anchor
         self._regex = self._construct_regular_expression(self.pattern)
         self._format = self._construct_format_expression(self.pattern)
+        self._placeholders = self._extract_placeholders(self.pattern)
 
     def __repr__(self):
         '''Return unambiguous representation of template.'''
@@ -98,6 +99,13 @@ class Template(object):
             )
         else:
             return path
+
+    def keys(self):
+        return self._placeholders
+
+    def _extract_placeholders(self, pattern):
+        match = _regex.findall(r'(?P<placeholder>{(.+?)(:(\\}|.)+?)?})', pattern)
+        return list(set([g[1] for g in match]))
 
     def _construct_format_expression(self, pattern):
         '''Return format expression from *pattern*.'''

--- a/test/unit/test_template.py
+++ b/test/unit/test_template.py
@@ -168,3 +168,25 @@ def test_escaping_pattern():
     expected = {'filename': 'filename', 'index': '0001', 'ext': 'ext'}
     assert template.parse('filename.0001.ext') == expected
 
+@pytest.mark.parametrize(('pattern', 'expected'), [
+    ('/static/string', []),
+    ('/single/{variable}', ['variable']),
+    ('/{variable}/{variable}', ['variable']),
+    ('/static/{variable:\d\{4\}}', ['variable']),
+    ('/{a}/static/{b}', ['a', 'b']),
+    ('/{a.b.c}/static/{a.b.d}', ['a.b.c', 'a.b.d']),
+    ('/{a}_{b}', ['a', 'b'])
+], ids=[
+    'static string',
+    'single variable',
+    'duplicate variable',
+    'custom variable expression',
+    'mix of static and variables',
+    'structured placeholders',
+    'neighbouring variables'
+])
+def test_extract_placeholders(pattern, expected):
+    '''Extract data from matching path.'''
+    template = Template('test', pattern)
+    placeholders = template.keys()
+    assert sorted(placeholders) == sorted(expected)


### PR DESCRIPTION
This allows someone to take a template such as `"/a/b/c/{d}_{e}.txt"` and get the keys (i.e. `['d', 'e']`) from it. It's tested. Without this, you'd need to find a string that matches and inspect the resulting dict.
