### PR TITLE
Python 3 Support - Bare Minimum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,7 @@
 # Packages
 *.egg
 *.egg-info
+.eggs
 dist
 build
 eggs
@@ -21,6 +22,7 @@ pip-log.txt
 
 # Unit test / coverage reports
 .coverage
+.pytest_cache
 
 # Translations
 *.mo

--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,7 @@ setup_requires = [
 ]
 
 install_requires = [
-
+    'six'
 ]
 
 # Readthedocs requires Sphinx extensions to be specified as part of

--- a/source/lucidity/template.py
+++ b/source/lucidity/template.py
@@ -3,6 +3,7 @@
 # :license: See LICENSE.txt.
 
 import abc
+import six
 import sys
 import re
 import functools
@@ -247,12 +248,11 @@ class Template(object):
                 'bad group name' in str(error),
                 'bad character in group name' in str(error)
             ]):
-                raise ValueError('Placeholder name contains invalid '
-                                 'characters.')
+                message = 'Placeholder name contains invalid characters.'
             else:
-                _, value, traceback = sys.exc_info()
-                message = 'Invalid pattern: {0}'.format(value)
-                raise ValueError, message, traceback  #@IgnorePep8
+                message = 'Invalid pattern: ' + str(error)
+
+            six.raise_from(ValueError(message), error)
 
         return compiled
 
@@ -303,10 +303,12 @@ class Template(object):
         return groups['placeholder']
 
 
-class Resolver(object):
-    '''Template resolver interface.'''
+# Python 2 and 3 compatible ABCMeta
+ABC = abc.ABCMeta('ABC', (object,), {})
 
-    __metaclass__ = abc.ABCMeta
+
+class Resolver(ABC):
+    '''Template resolver interface.'''
 
     @abc.abstractmethod
     def get(self, template_name, default=None):

--- a/test/unit/test_lucidity.py
+++ b/test/unit/test_lucidity.py
@@ -12,7 +12,7 @@ import lucidity
 
 TEST_TEMPLATE_PATH = os.path.join(
     os.path.dirname(__file__), '..', 'fixture', 'template'
-) 
+)
 
 
 @pytest.fixture
@@ -36,7 +36,7 @@ def test_discover(recursive, expected):
     templates = lucidity.discover_templates(
         [TEST_TEMPLATE_PATH], recursive=recursive
     )
-    assert map(operator.attrgetter('name'), templates) == expected
+    assert [t.name for t in templates] == expected
 
 
 @pytest.mark.parametrize(('path', 'expected'), [
@@ -50,7 +50,7 @@ def test_discover_with_env(path, expected, monkeypatch):
     '''Discover templates using environment variable.'''
     monkeypatch.setenv('LUCIDITY_TEMPLATE_PATH', path)
     templates = lucidity.discover_templates()
-    assert map(operator.attrgetter('name'), templates) == expected
+    assert [t.name for t in templates] == expected
 
 
 @pytest.mark.parametrize(('path', 'expected'), [


### PR DESCRIPTION
I noticed in the other pull request for Python 3 support there were some reservations on non-essential changes to the code base. In case that was holding up the merge, this pull request attempts to do the bare minimum to be py3 compatible.